### PR TITLE
v0.4.0.2

### DIFF
--- a/Docs/ReadMe.md
+++ b/Docs/ReadMe.md
@@ -2,7 +2,7 @@
 
 λ# releases are named after [Greek philosophers](https://en.wikipedia.org/wiki/List_of_ancient_Greek_philosophers).
 
-1. [Damo (v0.4.0.1) - 2010-11-12](ReleaseNotes-Damo.md)
+1. [Damo (v0.4.0.2) - 2010-11-13](ReleaseNotes-Damo.md)
 1. [Cebes (v0.3) - 2018-09-19](ReleaseNotes-Cebes.md)
 1. [Brontinus (v0.2) - 2018-08-13](ReleaseNotes-Brontinus.md)
 1. [Acrion (v0.1) - 2018-07-17](ReleaseNotes-Acrion.md)

--- a/Docs/ReleaseNotes-Damo.md
+++ b/Docs/ReleaseNotes-Damo.md
@@ -1,4 +1,4 @@
-# λ# - Damo (v0.4.0.1) - 2018-11-12
+# λ# - Damo (v0.4.0.2) - 2018-11-13
 
 > Damo was a Pythagorean philosopher said by many to have been the daughter of Pythagoras and Theano. [(Wikipedia)](https://en.wikipedia.org/wiki/Damo_(philosopher))
 
@@ -477,6 +477,12 @@ This method serializes an object into a JSON string using the built-in AWS Lambd
 * Lambda CloudWatch Logs are now configured to self-delete log stream entries after seven (7) days. In addition, the log group is now deleted when the function is deleted during module tear-down.
 
 ## Fixes
+
+### (v0.4.0.2) - 2018-11-13
+* [Fixed issue where λ# bucket discovery incorrectly defaulted back to the original bucket during deployment.](https://github.com/LambdaSharp/LambdaSharpTool/issues/60)
+* [Fixed issue where AWS profile was only set via `AWS_PROFILE` environment variable. Now `AWS_DEFAULT_PROFILE` is also set.](https://github.com/LambdaSharp/LambdaSharpTool/issues/61)
+* [Fixed issue where `config` did not default to `LAMBDASHARP_PROFILE` value when configuring a new CLI profile.](https://github.com/LambdaSharp/LambdaSharpTool/issues/62)
+* [Fixed issue where λ# Runtime module used a multi-region domain name pattern for S3 buckets that was incompatible with the `us-east-1` region.](https://github.com/LambdaSharp/LambdaSharpTool/issues/63)
 
 ### (v0.4.0.1) - 2018-11-12
 * [Fixed an issue where file packages did not get the correct name.](https://github.com/LambdaSharp/LambdaSharpTool/issues/57)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 ﻿![λ#](Docs/LambdaSharp_v2_small.png)
 
-# LambdaSharp CLI & Framework (v0.4.0.1)
+# LambdaSharp CLI & Framework (v0.4.0.2)
 
 **[Read what's new in the 0.4 "Damo" release.](Docs/ReleaseNotes-Damo.md)**
 

--- a/Runtime/LambdaSharp/Module.yml
+++ b/Runtime/LambdaSharp/Module.yml
@@ -163,7 +163,7 @@ Variables:
           DeploymentPrefix: !Ref DeploymentPrefix
           DeploymentPrefixLowercase: !Ref DeploymentPrefixLowercase
           DeploymentParent: !Ref AWS::StackName
-        TemplateURL: !Sub "http://${DeploymentBucketName}.s3-${AWS::Region}.amazonaws.com/Modules/LambdaSharpRegistrar/Versions/${Module::Version}/cloudformation.json"
+        TemplateURL: !Sub "https://${DeploymentBucketName}.s3.${AWS::Region}.amazonaws.com/Modules/LambdaSharpRegistrar/Versions/${Module::Version}/cloudformation.json"
         TimeoutInMinutes: 5
 
   - Var: S3Subscriber
@@ -182,7 +182,7 @@ Variables:
           DeploymentPrefix: !Ref DeploymentPrefix
           DeploymentPrefixLowercase: !Ref DeploymentPrefixLowercase
           DeploymentParent: !Ref AWS::StackName
-        TemplateURL: !Sub "http://${DeploymentBucketName}.s3-${AWS::Region}.amazonaws.com/Modules/LambdaSharpS3Subscriber/Versions/${Module::Version}/cloudformation.json"
+        TemplateURL: !Sub "https://${DeploymentBucketName}.s3.${AWS::Region}.amazonaws.com/Modules/LambdaSharpS3Subscriber/Versions/${Module::Version}/cloudformation.json"
         TimeoutInMinutes: 5
 
   - Var: S3PackageLoader
@@ -201,5 +201,5 @@ Variables:
           DeploymentPrefix: !Ref DeploymentPrefix
           DeploymentPrefixLowercase: !Ref DeploymentPrefixLowercase
           DeploymentParent: !Ref AWS::StackName
-        TemplateURL: !Sub "http://${DeploymentBucketName}.s3-${AWS::Region}.amazonaws.com/Modules/LambdaSharpS3PackageLoader/Versions/${Module::Version}/cloudformation.json"
+        TemplateURL: !Sub "https://${DeploymentBucketName}.s3.${AWS::Region}.amazonaws.com/Modules/LambdaSharpS3PackageLoader/Versions/${Module::Version}/cloudformation.json"
         TimeoutInMinutes: 5

--- a/src/MindTouch.LambdaSharp.Tool/Cli/ACliCommand.cs
+++ b/src/MindTouch.LambdaSharp.Tool/Cli/ACliCommand.cs
@@ -54,6 +54,7 @@ namespace MindTouch.LambdaSharp.Tool.Cli {
 
                 // select an alternate AWS profile by setting the AWS_PROFILE environment variable
                 Environment.SetEnvironmentVariable("AWS_PROFILE", awsProfile);
+                Environment.SetEnvironmentVariable("AWS_DEFAULT_PROFILE", awsProfile);
             }
 
             // determine default AWS region

--- a/src/MindTouch.LambdaSharp.Tool/Cli/CliConfigCommand.cs
+++ b/src/MindTouch.LambdaSharp.Tool/Cli/CliConfigCommand.cs
@@ -105,7 +105,7 @@ namespace MindTouch.LambdaSharp.Tool.Cli {
                 if(settings.ToolProfileExplicitlyProvided) {
                     Console.WriteLine($"Creating CLI profile: {settings.ToolProfile}");
                 } else {
-                    settings.ToolProfile = Prompt.GetString("CLI profile name:", "Default");
+                    settings.ToolProfile = Prompt.GetString("CLI profile name:", settings.ToolProfile);
                 }
                 if(moduleS3BucketName == "") {
                     Console.WriteLine($"Creating new S3 bucket");

--- a/src/MindTouch.LambdaSharp.Tool/MindTouch.LambdaSharp.Tool.csproj
+++ b/src/MindTouch.LambdaSharp.Tool/MindTouch.LambdaSharp.Tool.csproj
@@ -5,7 +5,7 @@
     <NoWarn>CS1998</NoWarn>
 
     <PackageId>MindTouch.LambdaSharp.Tool</PackageId>
-    <VersionPrefix>0.4.0.1</VersionPrefix>
+    <VersionPrefix>0.4.0.2</VersionPrefix>
     <Title>MindTouch λ#</Title>
     <Description>A serverless framework for rapid application development on AWS Lambda</Description>
     <Company>MindTouch, Inc.</Company>

--- a/src/update-nuget.sh
+++ b/src/update-nuget.sh
@@ -3,7 +3,7 @@
 # - allow LAMBDASHARP_SUFFIX to be passed in
 
 # Set version SUFFIX
-LAMBDASHARP_PREFIX=0.4.0.1
+LAMBDASHARP_PREFIX=0.4.0.2
 LAMBDASHARP_SUFFIX=
 
 update() {


### PR DESCRIPTION
Fixes:
* #60 - CLI cannot find runtime assets in public λ# bucket
* #61 - CLI does not set `AWS_DEFAULT_PROFILE` environment variable
* #62 - Read `LAMBDASHARP_PROFILE` environment variable in `config` command
* #63 - Runtime relies on S3 bucket pattern that is incompatible with `us-east-1`