### PR TITLE
v0.4.0.3

### DIFF
--- a/Docs/ReadMe.md
+++ b/Docs/ReadMe.md
@@ -2,7 +2,7 @@
 
 λ# releases are named after [Greek philosophers](https://en.wikipedia.org/wiki/List_of_ancient_Greek_philosophers).
 
-1. [Damo (v0.4.0.2) - 2010-11-13](ReleaseNotes-Damo.md)
+1. [Damo (v0.4.0.3) - 2010-12-16](ReleaseNotes-Damo.md)
 1. [Cebes (v0.3) - 2018-09-19](ReleaseNotes-Cebes.md)
 1. [Brontinus (v0.2) - 2018-08-13](ReleaseNotes-Brontinus.md)
 1. [Acrion (v0.1) - 2018-07-17](ReleaseNotes-Acrion.md)

--- a/Docs/ReleaseNotes-Damo.md
+++ b/Docs/ReleaseNotes-Damo.md
@@ -1,4 +1,4 @@
-# λ# - Damo (v0.4.0.2) - 2018-11-13
+# λ# - Damo (v0.4.0.3) - 2018-12-16
 
 > Damo was a Pythagorean philosopher said by many to have been the daughter of Pythagoras and Theano. [(Wikipedia)](https://en.wikipedia.org/wiki/Damo_(philosopher))
 
@@ -477,6 +477,13 @@ This method serializes an object into a JSON string using the built-in AWS Lambd
 * Lambda CloudWatch Logs are now configured to self-delete log stream entries after seven (7) days. In addition, the log group is now deleted when the function is deleted during module tear-down.
 
 ## Fixes
+
+### (v0.4.0.3) - 2018-12-16
+
+* [Fixed when Fn::Join always used "," to join items, no matter what separator was given](https://github.com/LambdaSharp/LambdaSharpTool/issues/77)
+* [Fixed VersionInfo `operator !=` (not equal) returned `false` when the references were not equal](https://github.com/LambdaSharp/LambdaSharpTool/issues/78)
+* [Fixed reference resolver sometimes failing to recognize legal expressions](https://github.com/LambdaSharp/LambdaSharpTool/issues/79)
+* [Fixed invalid wildcard assembly reference in generated .csproj file](https://github.com/LambdaSharp/LambdaSharpTool/issues/80)
 
 ### (v0.4.0.2) - 2018-11-13
 * [Fixed issue where λ# bucket discovery incorrectly defaulted back to the original bucket during deployment.](https://github.com/LambdaSharp/LambdaSharpTool/issues/60)

--- a/Docs/validate.sh
+++ b/Docs/validate.sh
@@ -127,7 +127,7 @@ fi
 
 dotnet tool uninstall \
     --global \
-    MindTouch.LambdaSharp.Tool \
+    MindTouch.LambdaSharp.Tool
 
 dotnet tool install \
     --global \

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 ﻿![λ#](Docs/LambdaSharp_v2_small.png)
 
-# LambdaSharp CLI & Framework (v0.4.0.2)
+# LambdaSharp CLI & Framework (v0.4.0.3)
 
 **[Read what's new in the 0.4 "Damo" release.](Docs/ReleaseNotes-Damo.md)**
 

--- a/src/MindTouch.LambdaSharp.Tool/AModelProcessor.cs
+++ b/src/MindTouch.LambdaSharp.Tool/AModelProcessor.cs
@@ -64,7 +64,7 @@ namespace MindTouch.LambdaSharp.Tool {
                 return parameters.First();
             }
             if(parameters.All(value => value is string)) {
-                return string.Join(",", parameters);
+                return string.Join(separator, parameters);
             }
             return new Dictionary<string, object> {
                 ["Fn::Join"] = new List<object> {

--- a/src/MindTouch.LambdaSharp.Tool/Cli/CliNewCommand.cs
+++ b/src/MindTouch.LambdaSharp.Tool/Cli/CliNewCommand.cs
@@ -304,7 +304,7 @@ namespace MindTouch.LambdaSharp.Tool.Cli {
                 ["LAMBDASHARP_PROJECT"] = useProjectReference
                     ? Path.GetRelativePath(projectDirectory, Path.Combine(lambdasharpDirectory, "src", "MindTouch.LambdaSharp", "MindTouch.LambdaSharp.csproj"))
                     : "(not used)",
-                ["LAMBDASHARP_VERSION"] = $"{Version.Major}.{Version.Minor}{Version.Suffix}*"
+                ["LAMBDASHARP_VERSION"] = Version.GetWildcardVersion()
             };
             try {
                 var projectContents = ReadResource(

--- a/src/MindTouch.LambdaSharp.Tool/MindTouch.LambdaSharp.Tool.csproj
+++ b/src/MindTouch.LambdaSharp.Tool/MindTouch.LambdaSharp.Tool.csproj
@@ -5,7 +5,7 @@
     <NoWarn>CS1998</NoWarn>
 
     <PackageId>MindTouch.LambdaSharp.Tool</PackageId>
-    <VersionPrefix>0.4.0.2</VersionPrefix>
+    <VersionPrefix>0.4.0.3</VersionPrefix>
     <Title>MindTouch λ#</Title>
     <Description>A serverless framework for rapid application development on AWS Lambda</Description>
     <Company>MindTouch, Inc.</Company>

--- a/src/MindTouch.LambdaSharp.Tool/ModelFunctionPackager.cs
+++ b/src/MindTouch.LambdaSharp.Tool/ModelFunctionPackager.cs
@@ -214,7 +214,13 @@ namespace MindTouch.LambdaSharp.Tool {
                         var libraryVersionText = include.Attribute("Version")?.Value;
                         if(libraryVersionText == null) {
                             AddError($"csproj file is missing a version attribute in its assembly reference for {library} (expected version: '{expectedVersion}')");
-                        } if(!VersionInfo.TryParse(libraryVersionText, out VersionInfo libraryVersion)) {
+                        } else if(libraryVersionText.EndsWith("*", StringComparison.Ordinal)) {
+                            if(!VersionInfo.TryParse(libraryVersionText.Substring(0, libraryVersionText.Length - 1), out VersionInfo libraryVersion)) {
+                                AddError($"csproj file contains an invalid wildcard version in its assembly reference for {library} (expected version: '{expectedVersion}', found: '{libraryVersionText}')");
+                            } else if(!libraryVersion.IsCompatibleWith(expectedVersion)) {
+                                AddError($"csproj file contains a mismatched assembly reference for {library} (expected version: '{expectedVersion}', found: '{libraryVersionText}')");
+                            }
+                        } else if(!VersionInfo.TryParse(libraryVersionText, out VersionInfo libraryVersion)) {
                             AddError($"csproj file contains an invalid version in its assembly reference for {library} (expected version: '{expectedVersion}', found: '{libraryVersionText}')");
                         } else if(!libraryVersion.IsCompatibleWith(expectedVersion)) {
                             AddError($"csproj file contains a mismatched assembly reference for {library} (expected version: '{expectedVersion}', found: '{libraryVersionText}')");

--- a/src/MindTouch.LambdaSharp.Tool/ModelReferenceResolver.cs
+++ b/src/MindTouch.LambdaSharp.Tool/ModelReferenceResolver.cs
@@ -427,8 +427,9 @@ DebugWriteLine($"FINAL => {value} [{value.GetType()}]");
                             : freeParameter.Reference;
                         break;
                     }
+                    return true;
                 }
-                return found != null;
+                return false;
             }
         }
     }

--- a/src/MindTouch.LambdaSharp.Tool/VersionInfo.cs
+++ b/src/MindTouch.LambdaSharp.Tool/VersionInfo.cs
@@ -66,7 +66,7 @@ namespace MindTouch.LambdaSharp.Tool {
         }
 
         public static bool operator != (VersionInfo left, VersionInfo right) {
-            if(!ReferenceEquals(left, right)) {
+            if(ReferenceEquals(left, right)) {
                 return false;
             }
             if(ReferenceEquals(left, null)) {
@@ -154,6 +154,20 @@ namespace MindTouch.LambdaSharp.Tool {
 
             // when Major version is 0, we rely on Minor and Build to match
             return ((Minor == other.Minor) && (Math.Max(0, Version.Build) == Math.Max(0, other.Version.Build)));
+        }
+
+        public string GetWildcardVersion() {
+            if(IsPreRelease) {
+
+                // NOTE (2018-12-16, bjorg): for pre-release version, there is no wildcard; the version must match everything
+                return ToString();
+            }
+            if(Major == 0) {
+
+                // when Major version is 0, the build number is relevant
+                return $"{Major}.{Minor}.{Math.Max(0, Version.Build)}.*";
+            }
+            return $"{Major}.{Minor}.*";
         }
     }
 }

--- a/src/update-nuget.sh
+++ b/src/update-nuget.sh
@@ -3,7 +3,7 @@
 # - allow LAMBDASHARP_SUFFIX to be passed in
 
 # Set version SUFFIX
-LAMBDASHARP_PREFIX=0.4.0.2
+LAMBDASHARP_PREFIX=0.4.0.3
 LAMBDASHARP_SUFFIX=
 
 update() {


### PR DESCRIPTION
Fixes:
* #77 - Fn::Join always uses "," to join items, no matter what separator is given
* #78 - VersionInfo operator != (not equal) returns false when the references are not equal
* #79 - Reference resolver sometimes failed to recognize legal expressions
* #80 - Wilcard in generated function .csproj is not valid