### PR TITLE
v0.4.0.4

### DIFF
--- a/Docs/Module-CustomResource.md
+++ b/Docs/Module-CustomResource.md
@@ -85,7 +85,7 @@ The <code>Handler</code> attribute specifies the name of an SNS topic parameter,
   Memory: 128
   Timeout: 30
   Sources:
-    - SNS: AccountReportGeneratorTopic
+    - Topic: AccountReportGeneratorTopic
 ```
 
 ### Custom Resource using a Lambda function
@@ -101,7 +101,7 @@ The <code>Handler</code> attribute specifies the name of an SNS topic parameter,
   Memory: 128
   Timeout: 30
   Sources:
-    - SNS: AccountReportGeneratorTopic
+    - Topic: AccountReportGeneratorTopic
 ```
 
 ## Notes

--- a/Docs/Module-Function.md
+++ b/Docs/Module-Function.md
@@ -143,5 +143,5 @@ The <code>Sources</code> section specifies zero or more source definitions the L
   Memory: 128
   Timeout: 15
   Sources:
-    - SNS: MySnsTopic
+    - Topic: MySnsTopic
 ```

--- a/Docs/ReadMe.md
+++ b/Docs/ReadMe.md
@@ -2,7 +2,7 @@
 
 λ# releases are named after [Greek philosophers](https://en.wikipedia.org/wiki/List_of_ancient_Greek_philosophers).
 
-1. [Damo (v0.4.0.3) - 2010-12-16](ReleaseNotes-Damo.md)
+1. [Damo (v0.4.0.4) - 2019-01-11](ReleaseNotes-Damo.md)
 1. [Cebes (v0.3) - 2018-09-19](ReleaseNotes-Cebes.md)
 1. [Brontinus (v0.2) - 2018-08-13](ReleaseNotes-Brontinus.md)
 1. [Acrion (v0.1) - 2018-07-17](ReleaseNotes-Acrion.md)

--- a/Docs/ReleaseNotes-Damo.md
+++ b/Docs/ReleaseNotes-Damo.md
@@ -1,4 +1,4 @@
-# λ# - Damo (v0.4.0.3) - 2018-12-16
+# λ# - Damo (v0.4.0.4) - 2019-01-11
 
 > Damo was a Pythagorean philosopher said by many to have been the daughter of Pythagoras and Theano. [(Wikipedia)](https://en.wikipedia.org/wiki/Damo_(philosopher))
 
@@ -401,7 +401,7 @@ Custom resource definitions create new types of resources that can be used by ot
   Memory: 128
   Timeout: 30
   Sources:
-    - SNS: AccountReportGeneratorTopic
+    - Topic: AccountReportGeneratorTopic
 ```
 See [custom resource documentation](Module-CustomResource.md) for more details.
 
@@ -477,6 +477,13 @@ This method serializes an object into a JSON string using the built-in AWS Lambd
 * Lambda CloudWatch Logs are now configured to self-delete log stream entries after seven (7) days. In addition, the log group is now deleted when the function is deleted during module tear-down.
 
 ## Fixes
+
+### (v0.4.0.4) - 2019-01-11
+
+* [Fixed LambdaSharp modules are always installed from public lambdasharp bucket](https://github.com/LambdaSharp/LambdaSharpTool/issues/82)
+* [Fixed documentation error that showed wrong keyword for subscribing a function to a topic](https://github.com/LambdaSharp/LambdaSharpTool/issues/83)
+* [Fixed cannot unzip package from deployment bucket when S3PackageLoader is installed from the global lambdasharp bucket](https://github.com/LambdaSharp/LambdaSharpTool/issues/84)
+* [Fixed error when creating a resource with custom resource type](https://github.com/LambdaSharp/LambdaSharpTool/issues/85)
 
 ### (v0.4.0.3) - 2018-12-16
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 ﻿![λ#](Docs/LambdaSharp_v2_small.png)
 
-# LambdaSharp CLI & Framework (v0.4.0.3)
+# LambdaSharp CLI & Framework (v0.4.0.4)
 
 **[Read what's new in the 0.4 "Damo" release.](Docs/ReleaseNotes-Damo.md)**
 

--- a/Runtime/LambdaSharpS3PackageLoader/Module.yml
+++ b/Runtime/LambdaSharpS3PackageLoader/Module.yml
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 Module: LambdaSharpS3PackageLoader
-Version: 0.4
+Version: 0.4.0.1
 Description: LambdaSharp S3 Package Loader
 
 Outputs:
@@ -41,8 +41,8 @@ Variables:
   - Var: S3DeploymentBucketPermissions
     Description: LambdaSharpS3PackageLoader requires read-write access to all S3 buckets
     Value:
-      - !Sub "arn:aws:s3:::${DeploymentBucketName}"
-      - !Sub "arn:aws:s3:::${DeploymentBucketName}/*"
+      - !Sub "arn:aws:s3:::*"
+      - !Sub "arn:aws:s3:::*/*"
     Resource:
       Type: AWS::S3::Bucket
       Allow: ReadOnly

--- a/src/MindTouch.LambdaSharp.Tool/Cli/CliBuildCommand.cs
+++ b/src/MindTouch.LambdaSharp.Tool/Cli/CliBuildCommand.cs
@@ -615,10 +615,10 @@ namespace MindTouch.LambdaSharp.Tool.Cli {
                         if(HasErrors) {
                             return false;
                         }
-                        if(foundVersion == null) {
-                            continue;
+                        if(foundVersion != null) {
+                            manifestPath = $"Modules/{moduleName}/Versions/{foundVersion}/manifest.json";
+                            break;
                         }
-                        manifestPath = $"Modules/{moduleName}/Versions/{foundVersion}/manifest.json";
                     }
                     if(manifestPath == null) {
                         AddError($"could not find module: {moduleName} (v{requestedVersion})");

--- a/src/MindTouch.LambdaSharp.Tool/MindTouch.LambdaSharp.Tool.csproj
+++ b/src/MindTouch.LambdaSharp.Tool/MindTouch.LambdaSharp.Tool.csproj
@@ -5,7 +5,7 @@
     <NoWarn>CS1998</NoWarn>
 
     <PackageId>MindTouch.LambdaSharp.Tool</PackageId>
-    <VersionPrefix>0.4.0.3</VersionPrefix>
+    <VersionPrefix>0.4.0.4</VersionPrefix>
     <Title>MindTouch λ#</Title>
     <Description>A serverless framework for rapid application development on AWS Lambda</Description>
     <Company>MindTouch, Inc.</Company>

--- a/src/MindTouch.LambdaSharp.Tool/ModelConverter.cs
+++ b/src/MindTouch.LambdaSharp.Tool/ModelConverter.cs
@@ -597,7 +597,7 @@ namespace MindTouch.LambdaSharp.Tool {
                     }
 
                     // convert type name to a custom AWS resource type
-                    resource.Type = "Custom::" + customResourceName;
+                    resource.Type = "Custom::" + customResourceName.Replace("::", "");
                 }
             });
             return new Resource {

--- a/src/update-nuget.sh
+++ b/src/update-nuget.sh
@@ -3,7 +3,7 @@
 # - allow LAMBDASHARP_SUFFIX to be passed in
 
 # Set version SUFFIX
-LAMBDASHARP_PREFIX=0.4.0.3
+LAMBDASHARP_PREFIX=0.4.0.4
 LAMBDASHARP_SUFFIX=
 
 update() {


### PR DESCRIPTION
Fixes:

#82 - LambdaSharp modules are always installed from public lambdasharp bucket
#83 - Documentation error that showed wrong keyword for subscribing a function to a topic
#84 - Cannot unzip package from deployment bucket when S3PackageLoader is installed from the global lambdasharp bucket
#85 - Error when creating a resource with custom resource type
