### PR TITLE
Feature extend api auth v0.7

### DIFF
--- a/src/LambdaSharp.Tool/Cli/Build/ModelAstToModuleConverter.cs
+++ b/src/LambdaSharp.Tool/Cli/Build/ModelAstToModuleConverter.cs
@@ -155,6 +155,8 @@ namespace LambdaSharp.Tool.Cli.Build {
                         Path = path,
                         Integration = integration,
                         OperationName = source.OperationName,
+                        AuthorizerId = source.AuthorizerId,
+                        AuthorizationScopes =  source.AuthorizationScopes,
                         ApiKeyRequired = source.ApiKeyRequired,
                         Invoke = source.Invoke
                     };

--- a/src/LambdaSharp.Tool/Cli/Build/ModelFunctionCompiler.cs
+++ b/src/LambdaSharp.Tool/Cli/Build/ModelFunctionCompiler.cs
@@ -836,6 +836,8 @@ namespace LambdaSharp.Tool.Cli.Build {
                     HttpMethod = source.HttpMethod,
                     OperationName = source.OperationName,
                     ApiKeyRequired = source.ApiKeyRequired,
+                    AuthorizerId = source.AuthorizerId,
+                    AuthorizationScopes =  source.AuthorizationScopes,
                     ResourceId = parentId,
                     RestApiId = restApiId,
                     Integration = new Humidifier.ApiGateway.MethodTypes.Integration {
@@ -856,6 +858,8 @@ namespace LambdaSharp.Tool.Cli.Build {
                     HttpMethod = source.HttpMethod,
                     OperationName = source.OperationName,
                     ApiKeyRequired = source.ApiKeyRequired,
+                    AuthorizerId = source.AuthorizerId,
+                    AuthorizationScopes =  source.AuthorizationScopes,
                     ResourceId = parentId,
                     RestApiId = restApiId,
                     Integration = new Humidifier.ApiGateway.MethodTypes.Integration {

--- a/src/LambdaSharp.Tool/Model/AFunctionSource.cs
+++ b/src/LambdaSharp.Tool/Model/AFunctionSource.cs
@@ -66,6 +66,9 @@ namespace LambdaSharp.Tool.Model {
         public string[] Path { get; set; }
         public ApiGatewaySourceIntegration Integration { get; set; }
         public string OperationName { get; set; }
+
+        public string AuthorizerId { get; set; }
+        public string[] AuthorizationScopes { get; set; }
         public bool? ApiKeyRequired { get; set; }
         public string Invoke { get; set; }
         public string RequestContentType { get; set; }

--- a/src/LambdaSharp.Tool/Model/AFunctionSource.cs
+++ b/src/LambdaSharp.Tool/Model/AFunctionSource.cs
@@ -67,7 +67,7 @@ namespace LambdaSharp.Tool.Model {
         public ApiGatewaySourceIntegration Integration { get; set; }
         public string OperationName { get; set; }
 
-        public string AuthorizerId { get; set; }
+        public object AuthorizerId { get; set; }
         public string[] AuthorizationScopes { get; set; }
         public bool? ApiKeyRequired { get; set; }
         public string Invoke { get; set; }

--- a/src/LambdaSharp.Tool/Model/AFunctionSource.cs
+++ b/src/LambdaSharp.Tool/Model/AFunctionSource.cs
@@ -66,7 +66,6 @@ namespace LambdaSharp.Tool.Model {
         public string[] Path { get; set; }
         public ApiGatewaySourceIntegration Integration { get; set; }
         public string OperationName { get; set; }
-
         public object AuthorizerId { get; set; }
         public string[] AuthorizationScopes { get; set; }
         public bool? ApiKeyRequired { get; set; }

--- a/src/LambdaSharp.Tool/Model/AST/FunctionSourceNode.cs
+++ b/src/LambdaSharp.Tool/Model/AST/FunctionSourceNode.cs
@@ -76,7 +76,6 @@ namespace LambdaSharp.Tool.Model.AST {
         public string Integration { get; set; }
         public string OperationName { get; set; }
         public bool? ApiKeyRequired { get; set; }
-
         public string AuthorizerId { get; set; }
         public string[] AuthorizationScopes { get; set; }
         public string Invoke { get; set; }

--- a/src/LambdaSharp.Tool/Model/AST/FunctionSourceNode.cs
+++ b/src/LambdaSharp.Tool/Model/AST/FunctionSourceNode.cs
@@ -30,6 +30,8 @@ namespace LambdaSharp.Tool.Model.AST {
                 "Integration",
                 "OperationName",
                 "ApiKeyRequired",
+                "AuthorizerId",
+                "AuthorizationScopes",
                 "Invoke"
             },
             ["Schedule"] = new[] {
@@ -74,6 +76,9 @@ namespace LambdaSharp.Tool.Model.AST {
         public string Integration { get; set; }
         public string OperationName { get; set; }
         public bool? ApiKeyRequired { get; set; }
+
+        public string AuthorizerId { get; set; }
+        public string[] AuthorizationScopes { get; set; }
         public string Invoke { get; set; }
 
         // CloudWatch Schedule Event Source

--- a/src/LambdaSharp.Tool/Model/AST/FunctionSourceNode.cs
+++ b/src/LambdaSharp.Tool/Model/AST/FunctionSourceNode.cs
@@ -76,7 +76,8 @@ namespace LambdaSharp.Tool.Model.AST {
         public string Integration { get; set; }
         public string OperationName { get; set; }
         public bool? ApiKeyRequired { get; set; }
-        public string AuthorizerId { get; set; }
+        public string AuthorizationType { get; set; }
+        public object AuthorizerId { get; set; }
         public string[] AuthorizationScopes { get; set; }
         public string Invoke { get; set; }
 


### PR DESCRIPTION
Add support for cloudformation JSON output to have `AuthorizerId` and `AuthorizationScopes` for API Gateway methods.

Here is an example

```yml

  - Resource: Authorizer
    Description: Use AWS Cognito 
    Type: AWS::ApiGateway::Authorizer
    Properties:
      IdentitySource: "method.request.header.Authorization"
      Name: Authorizer
      ProviderARNs:
        - !Ref CognitoUserPoolArn
      RestApiId: !Ref Module::RestApi
      Type: COGNITO_USER_POOLS

  - Function: AnExampleApiGatewayLambdaFunction
    Description: Api endpoints
    Memory: 256
    Timeout: 30
    Sources:
      - Api: GET:/example
        AuthorizerId: !Ref Authorizer
        AuthorizationScopes: 
          - "org/read"
          - "org/write"
        Invoke: GetExampleRequest
```
