### PR TITLE
Adding Pragma: Role.PermissionsBoundary

### DIFF
--- a/src/DocFx/syntax/Module-Pragmas.md
+++ b/src/DocFx/syntax/Module-Pragmas.md
@@ -24,6 +24,7 @@ Pragmas are used to change the default processing behavior of the LambdaSharp CL
 |`Module::RestApi.EndpointConfiguration`     |Expression for setting the REST API endpoint.                                       |(none)                                 |
 |`Module::RestApi.Policy`                    |Expression for setting the REST API policy.                                         |(none)                                 |
 |`Module::WebSocket.RouteSelectionExpression`|Expression for determining the WebSocket route.                                     |`$request.body.action`                 |
+|`Module::Role.PermissionsBoundary`          |Expression for setting the PermissionsBoundary attribute on the function IAM role.  |(none)                                 |
 
 ### Examples
 

--- a/src/LambdaSharp.Tool/Cli/Build/ModelModuleInitializer.cs
+++ b/src/LambdaSharp.Tool/Cli/Build/ModelModuleInitializer.cs
@@ -177,6 +177,7 @@ namespace LambdaSharp.Tool.Cli.Build {
             );
 
             // create module IAM role used by all functions
+            _builder.TryGetOverride("Module::Role.PermissionsBoundary", out var rolePermissionsBoundary);
             var moduleRoleItem = _builder.AddResource(
                 parent: moduleItem,
                 name: "Role",
@@ -196,6 +197,7 @@ namespace LambdaSharp.Tool.Cli.Build {
                             }
                         }.ToList()
                     },
+                    PermissionsBoundary = rolePermissionsBoundary,
                     Policies = new[] {
                         new Humidifier.IAM.Policy {
                             PolicyName = FnSub("${AWS::StackName}ModulePolicy"),


### PR DESCRIPTION
Adding `Pragma: Role.PermissionsBoundary` to set the `PermissionsBoundary` property on the function IAM Role. By default the property is omitted.

Example usage:

```
Pragmas:
  - Overrides:
      Module::Role.PermissionsBoundary: !Sub "arn:aws:iam::${AWS::AccountId}:policy/permissions-boundaries"
```

Resolves: https://github.com/LambdaSharp/LambdaSharpTool/issues/145