### PR TITLE
v0.8.0.8

### DIFF
--- a/Docs/articles/ReleaseNotes-Hicetas.md
+++ b/Docs/articles/ReleaseNotes-Hicetas.md
@@ -4,7 +4,7 @@ description: Release notes for LambdaSharp "Hicetas" (v0.8)
 keywords: release, notes, hicetas
 ---
 
-# LambdaSharp "Hicetas" Release (v0.8.0.7) - 2020-07-28
+# LambdaSharp "Hicetas" Release (v0.8.0.8) - 2020-08-03
 
 > Hicetas was a Greek philosopher of the Pythagorean School. He was born in Syracuse. Like his fellow Pythagorean Ecphantus and the Academic Heraclides Ponticus, he believed that the daily movement of permanent stars was caused by the rotation of the Earth around its axis. When Copernicus referred to Nicetus Syracusanus (Nicetus of Syracuse) in _De revolutionibus orbium coelestium_ as having been cited by Cicero as an ancient who also argued that the Earth moved, it is believed that he was actually referring to Hicetas. [(Wikipedia)](https://en.wikipedia.org/wiki/Hicetas)
 
@@ -140,6 +140,13 @@ Part of this release, _LambdaSharp.Core_ functions were ported to .NET Core 3.1 
 
 
 ## Releases
+
+### (v0.8.0.8) - 2020-08-03
+
+#### Fixes
+
+* CLI
+  * Fixed a regression in `lash init --quick-start` that failed to create the initial S3 bucket.
 
 ### (v0.8.0.7) - 2020-07-28
 


### PR DESCRIPTION
#### Fixes

* CLI
  * Fixed a regression in `lash init --quick-start` that failed to create the initial S3 bucket.
