### PR TITLE
Add null check to ModelManifestLoader.cs

### DIFF
--- a/src/LambdaSharp.Tool/ModelManifestLoader.cs
+++ b/src/LambdaSharp.Tool/ModelManifestLoader.cs
@@ -715,7 +715,8 @@ namespace LambdaSharp.Tool {
 
             // never cache pre-release versions or when the module origin is not set
             if(
-                moduleLocation.ModuleInfo.Version.IsPreRelease()
+                moduleLocation?.ModuleInfo?.Version == null
+                || moduleLocation.ModuleInfo.Version.IsPreRelease()
                 || (moduleLocation.ModuleInfo.Origin is null)
             ) {
                 return null;


### PR DESCRIPTION
Summary
- Adds a null check to avoid NRE when accessing moduleLocation.ModuleInfo in ModelManifestLoader.cs.  